### PR TITLE
Fixed "[DEPRECATION WARNING]"

### DIFF
--- a/tasks/setup.yml
+++ b/tasks/setup.yml
@@ -1,6 +1,6 @@
 ---
 - name: Download archive from S3
-  s3:
+  aws_s3:
     bucket: "{{ s3_bucket }}"
     object: "{{ s3_object }}"
     dest: "{{ download_destination_file }}"


### PR DESCRIPTION
[DEPRECATION WARNING]: The 's3' module is being renamed 'aws_s3'. This feature will be removed in version 2.7